### PR TITLE
Fix empty TMPDIR expansion

### DIFF
--- a/beaker
+++ b/beaker
@@ -17,9 +17,8 @@ shell-lib/docker/check_docker-compose.sh || echo "You do not have a supported ve
 
 # TMPDIR is erased even if -E is passed to sudo. https://serverfault.com/questions/478741/sudo-does-not-preserve-tmpdir
 # Need to explicitly pass tmpdir in if it exists. Expands to nothing if TMPDIR doesn't exist.
-TMP_DIR=${TMPDIR:+TMPDIR=$TMPDIR}
-if [ -z "$TMP_DIR" ]; then
-	$SUDO env "$TMP_DIR" docker-compose -f "docker-compose.yml" "$@"
+if [ -n "$TMPDIR" ]; then
+	$SUDO env "TMPDIR=$TMPDIR" docker-compose -f "docker-compose.yml" "$@"
 else
 	$SUDO docker-compose -f "docker-compose.yml" "$@"
 fi

--- a/beaker
+++ b/beaker
@@ -16,7 +16,7 @@ shell-lib/docker/check_docker.sh || echo "You do not have a supported version of
 shell-lib/docker/check_docker-compose.sh || echo "You do not have a supported version of Docker-Compose installed."
 
 # TMPDIR is erased even if -E is passed to sudo. https://serverfault.com/questions/478741/sudo-does-not-preserve-tmpdir
-# Need to explicitly pass tmpdir in if it exists. Expands to nothing if TMPDIR doesn't exist.
+# Need to explicitly pass tmpdir in if it exists.
 if [ -n "$TMPDIR" ]; then
 	$SUDO env "TMPDIR=$TMPDIR" docker-compose -f "docker-compose.yml" "$@"
 else

--- a/beaker
+++ b/beaker
@@ -17,8 +17,12 @@ shell-lib/docker/check_docker-compose.sh || echo "You do not have a supported ve
 
 # TMPDIR is erased even if -E is passed to sudo. https://serverfault.com/questions/478741/sudo-does-not-preserve-tmpdir
 # Need to explicitly pass tmpdir in if it exists. Expands to nothing if TMPDIR doesn't exist.
-
-$SUDO env "${TMPDIR:+TMPDIR=$TMPDIR}" docker-compose -f "docker-compose.yml" "$@"
+TMP_DIR=${TMPDIR:+TMPDIR=$TMPDIR}
+if [ -z "$TMP_DIR" ]; then
+	$SUDO env "$TMP_DIR" docker-compose -f "docker-compose.yml" "$@"
+else
+	$SUDO docker-compose -f "docker-compose.yml" "$@"
+fi
 
 # Store the exit code from docker-compose to use later
 result=$?


### PR DESCRIPTION
Closes #7

Another option here was to set `TMPDIR` using `require_executable_tmp_dir` from `acm_lib.sh`.
We determined the conditional was the best fix.