### PR TITLE
Automated release generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Generate and upload a release tarball
+
+on:
+  release:
+    types:
+      - created
+      - edited
+
+jobs:
+  upload:
+    name: Upload Artifacts
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - run: shell-lib/docker/install_docker.sh
+      - run: installer/generate_installer.sh
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: installer/BeaKer.tar
+          # Note: This will fail if the asset already exists 
+          # (e.g. editing a release w/o deleting the existing asset)
+          asset_name: BeaKer.tar
+          asset_content_type: application/x-tar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Generate and upload a release tarball
+name: Generate and upload a release assets
 
 on:
   release:
@@ -26,3 +26,13 @@ jobs:
           # (e.g. editing a release w/o deleting the existing asset)
           asset_name: BeaKer.tar
           asset_content_type: application/x-tar
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: agent/install-sysmon-beats.ps1
+          # Note: This will fail if the asset already exists 
+          # (e.g. editing a release w/o deleting the existing asset)
+          asset_name: install-sysmon-beats.ps1
+          asset_content_type: text/plain

--- a/docs/Installation and Release Generation.md
+++ b/docs/Installation and Release Generation.md
@@ -1,39 +1,89 @@
 # Installation and Release Generation
 
-## `install_beaker.sh`
+## Generating a Release on Github
+### One-Time Release
 
-### Description
+1. Create a new [GitHub release](https://github.com/activecm/BeaKer/releases)
+  - Name both the tag and the release with the version (e.g. `v1.0.0`)
+  - Optionally upload assets to be included (*see below)
+2. Publish the release. After a few minutes the assets will be automatically generated and attached to the release.
+
+*Optional manual asset generation
+
+Even if you do not attach any assets to a release they will be automatically generated and uploaded for you. If needed, you can upload `BeaKer.tar` manually before publishing the release. Run the script `installer/generate_installer.sh` on a clean working directory to generate `BeaKer.tar` (see the [`generate_installer.sh`](#generate_installersh) section below for more information on this script).
+
+### Pre-Releases
+
+1. Create a new [GitHub release](https://github.com/activecm/BeaKer/releases)
+  - Name the tag with the current release candidate revision (e.g. `v1.0.0-rc1`)
+  - Name the release with the version (e.g. `v1.0.0`)
+  - Check the box to mark the release as a pre-release
+
+![image](https://user-images.githubusercontent.com/1696711/80836467-6d2c0200-8bba-11ea-9629-168ddb4442fc.png)
+
+2. Publish the release. After a few minutes the assets will be automatically generated and attached to the release.
+
+![image](https://user-images.githubusercontent.com/1696711/80836790-212d8d00-8bbb-11ea-920a-b6c2baec79bb.png)
+
+**For subsequent test releases:**
+
+3. Edit the release and perform the following:
+  - Edit the release message. This usually means adding the new change's summary to the changelog.
+  - Increment the version tag to be the next rc revision (e.g. `v1.0.0-rc2`). This ensures new changes in master will be included.
+  - Delete the existing `BeaKer.tar` asset that is attached (and any other assets). This ensures the asset will be regenerated.
+  - Save the changes to the pre-release.
+
+![image](https://user-images.githubusercontent.com/1696711/80836844-373b4d80-8bbb-11ea-90ae-0f9da6fd24a3.png)
+
+4. Repeat step 3 as needed.
+
+**When ready to publish a final version:**
+
+5. Edit the release. Since no further changes have been made there is no need to edit the release message or regenerate `BeaKer.tar` or other assets. The latest release candidate has now become the final version so all that remains is adding the final version tag.
+  - Change the version tag and remove the rc revision (e.g. `v1.0.0-rc2` -> `v1.0.0`).
+  - Uncheck the pre-release box and publish the release.
+
+![image](https://user-images.githubusercontent.com/1696711/80836917-5fc34780-8bbb-11ea-98f2-d80915379ea9.png)
+
+### Notes
+
+The steps above were written with the following behaviors in mind. Use these as a reference if you need to troubleshoot, modify the workflow, or Github's behavior changes.
+
+- An installer `BeaKer.tar` is generated and uploaded as a release asset whenever a release is created or edited. This is triggered by the `release.yml` workflow.
+- This does not apply to "draft" releases. But it applies to pre-releases.
+- When you first create a release you make a tag from a specific branch. Even if you edit the content of a release later it keeps the original tag referencing the original commit. This means that if you add new commits to the branch, you will need to create a new tag in order to have the release inclued the new commits.
+- In order to trigger the "edited" event in the workflow you have to actually change the release message.
+- If the `BeaKer.tar` asset already exists in a release it will not be replaced. In order to have it regenerated and replaced you need to delete the `BeaKer.tar` file when editing the release.
+- Check https://github.com/activecm/BeaKer/actions/ if your release is not being automatically generated to troubleshoot.
+- Updating the `release.yml` workflow seems to only apply in the master branch. If you need to debug or make changes to the workflow it is best to fork the repository and test there first.
+
+## Component Overview
+
+### `install_beaker.sh`
+
 `install_beaker.sh` installs Docker, Docker-Compose, and the BeaKer server on the local machine.
-
-### Quick Usage
 
 ```bash
 installer/stage/install_beaker.sh
 ```
 
-## `stage`
-### Description
-The stage folder holds exactly one folder which will be what the user sees when they unpack the corresponding tarball.
+### `stage`
 
-### Quick Usage
+The stage folder holds exactly one folder which will be what the user sees when they unpack the corresponding tarball.
 
 In order to add a file to the release tarball, either create a file inside the `stage` directory, or symlink it in with `ln -s`.
 
 You can also modify the `generate_installer.sh` script to download or generate a file in the `stage` directory, but then be sure you add the name of this file to the `stage/.gitignore` file to avoid committing it.
 
-## `generate_installer.sh`
-
-### Quick Usage
-
-```bash
-scripts/installer/generate_installer.sh
-```
-
-### Description
+### `generate_installer.sh`
 
 The stage directory is built into a corresponding tarball by the accompanying `generate_installer.sh` file.
 
-### Detailed Usage
+```bash
+installer/generate_installer.sh
+```
+
+#### Detailed Usage
 
 By default, the script will pull all latest base images from the remote container repos and then force a local rebuild from scratch (i.e. not using the cache). This reasonably ensures everything is up to date and there are no issues caused by caching. It doesn't (yet) prevent you from having uncomitted or untagged changes to your local source code so beware of this.
 
@@ -58,11 +108,3 @@ Or if you want to have the installer do a fresh build but you are fine speeding 
 ```bash
 scripts/installer/generate_installer.sh --use-cache --no-pull
 ```
-
-## Generating a Release
-- Ensure you are on the latest commit of the master branch with no uncommitted changes
-- Run the script `./installer/generate_installer.sh` to generate `BeaKer.tar`
-- Tag the current commit with the appropriate version
-- Create a new [GitHub release](https://github.com/activecm/BeaKer/releases)
-  - Use the new version tag that was just created
-  - Upload the `BeaKer.tar` file that was generated

--- a/installer/generate_installer.sh
+++ b/installer/generate_installer.sh
@@ -65,8 +65,16 @@ BEAKER_ARCHIVE=BeaKer
 STAGE_DIR="$SCRIPT_DIR/stage/$BEAKER_ARCHIVE"
 
 # Make sure we can use docker-compose
-shell-lib/docker/check_docker.sh || warn "You do not have a supported version of Docker installed."
-shell-lib/docker/check_docker-compose.sh || warn "You do not have a supported version of Docker-Compose installed."
+shell-lib/docker/check_docker.sh || {
+	echo -e "\e[93mWARNING\e[0m: The generator did not detect a supported version of Docker."
+	echo "         A supported version of Docker can be installed by running"
+	echo "         the install_docker.sh script in the scripts directory."
+}
+shell-lib/docker/check_docker-compose.sh || {
+	echo -e "\e[93mWARNING\e[0m: The generator did not detect a supported version of Docker-Compose."
+	echo "         A supported version of Docker-Compose can be installed by running"
+	echo "         the install_docker.sh script in the scripts directory."
+}
 
 export COMPOSE_FILE="docker-compose.yml"
 


### PR DESCRIPTION
I tested this on a forked repo and it seems to be working. Here are some notes:
- An installer is generated and uploaded as a release asset whenever a release is created or edited.
- This does not apply to "draft" releases. But it applies to pre-releases.
- When you first create a release you make a tag from a specific branch. Even if you edit the content of a release later it keeps the original tag. This means that if you make updates to the code, you will need to create a new tag in order to have the release refer to the new changes.
- In order to trigger the "edited" event you have to actually change the release message.
- If the "BeaKer.tar" asset already exists in a release and you edit it, it will not be replaced. In order to have it regenerated and replaced, you need to delete the "BeaKer.tar" file when editing the release.

None of these are problems if we just create a new release. However, if we want to re-use an existing release and update it here is the workflow I see:
1) Create a new pre-release and publish it. Name the release with the version (e.g. v1.0.0). Name the tag with the current release candidate revision (e.g. v1.0.0-rc1). A few minutes later, the `BeaKer.tar` asset will be generated and attached to the release.
![image](https://user-images.githubusercontent.com/1696711/80836467-6d2c0200-8bba-11ea-9629-168ddb4442fc.png)
![image](https://user-images.githubusercontent.com/1696711/80836790-212d8d00-8bbb-11ea-920a-b6c2baec79bb.png)

2) If an update is made, edit the release and perform the following:
  a) Edit the release message. This usually means adding the new change's summary to the changelog.
  b) Increment the version tag to be the next rc revision (e.g. v1.0.0-rc2). This ensures new changes in master will be included.
  c) Delete the existing `BeaKer.tar` asset that is attached. This ensures the asset will be regenerated.
  d) Save the changes to the pre-release.
![image](https://user-images.githubusercontent.com/1696711/80836844-373b4d80-8bbb-11ea-90ae-0f9da6fd24a3.png)

3) Repeat step 2 as needed.

4) When ready for a final release perform the following steps. Since no further changes have been made there is no need to edit the release message or regenerate the `BeaKer.tar`. The latest release candidate has now become the final version so all that remains is adding the final version tag.
  a) Change the version tag and remove the rc revision (e.g. v1.0.0-rc2 -> v1.0.0).
  b) Uncheck the pre-release box and publish the release.
![image](https://user-images.githubusercontent.com/1696711/80836917-5fc34780-8bbb-11ea-98f2-d80915379ea9.png)

If this sounds reasonable I'll update the [docs](https://github.com/activecm/BeaKer/blob/master/docs/Installation%20and%20Release%20Generation.md) to include this info.
