### PR TITLE
Install Beaker in /opt; Link Beaker Script in /usr/local/bin; Fix Dashboard Loading

### DIFF
--- a/beaker
+++ b/beaker
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Change dir to script dir
-pushd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null
+pushd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" > /dev/null
 
 
 # If the current user doesn't have docker permissions or

--- a/installer/stage/BeaKer/install_beaker.sh
+++ b/installer/stage/BeaKer/install_beaker.sh
@@ -39,7 +39,7 @@ BEAKER_CONFIG_DIR="${BEAKER_CONFIG_DIR:-/etc/BeaKer/}"
 test_system () {
     status "Checking minimum requirements"
     require_supported_os
-    require_free_space "$HOME" "/var/lib" "/etc" "/usr" 5120
+    require_free_space_MB "$HOME" "/var/lib" "/etc" "/usr" 5120
 }
 
 install_docker () {

--- a/kibana/import_dashboards.sh
+++ b/kibana/import_dashboards.sh
@@ -20,7 +20,8 @@ read_password() {
 
 main () {
     local es_pass="$(read_password)"
-    local resp=`curl -u "elastic:$es_pass" -X POST -k "https://localhost:5601/api/saved_objects/_import?overwrite=true" -H "kbn-xsrf: true" -F file=@$DASHBOARD_FILE`
+    local resp # local resp has to be separate from the next line to generate a valid $? for the curl command
+    resp=`curl --fail -u "elastic:$es_pass" -X POST -k "https://localhost:5601/api/saved_objects/_import?overwrite=true" -H "kbn-xsrf: true" -F file=@$DASHBOARD_FILE`
     if [ $? -ne 0 -o "$resp" == "Kibana server is not ready yet" ]; then
         exit 2
     fi


### PR DESCRIPTION
This PR changes the installer to move the install bundle to /opt/BeaKer and link the `beaker` script into `/usr/local/bin`. 

Additionally, while developing this patch, I noticed that the installer was failing to load the dashboards in. There is logic in the installer to try to reload dashboards if the load fails. However, it wasn't getting activated. It turns out there was a subtle bug in the import_dashboards script. If you run `local myVar=$(exit 1)` `$?` will not equal `1`. It will equal `0`. This is because `local (subexpr)` runs after the subshell. To avoid this, you must declare the variable as a local ahead of the assignment. 

I also noticed that a path was unquoted in shell-lib's move_working_directory implementation, so I fixed that up.