### PR TITLE
Update readme example commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ The automated installer will:
   - Set the Elasticsearch superuser password for the `elastic` account
   - Set the `sysmon-ingest` user password for connecting WinLogBeats
 
-The `./beaker` script inside of the release tar file is a wrapper around `docker-compose` and can be used to manage BeaKer.
- - To stop BeaKer, run `./beaker down`
- - To start Beaker, run `./beaker up`
- - To view the logs of the Elasticsearch container, run `./beaker logs -f beaker_elasticsearch_1`
- - To view the logs of the Kibana container, run `./beaker logs -f beaker_kibana_1`
+The `beaker` script installed to `/usr/local/bin/beaker` is a wrapper around `docker-compose` and can be used to manage BeaKer.
+ - To stop BeaKer, run `beaker down`
+ - To start Beaker, run `beaker up`
+ - To view the logs of the Elasticsearch container, run `beaker logs -f elasticsearch`
+ - To view the logs of the Kibana container, run `beaker logs -f kibana`
 
 After running `./install_beaker.sh` you should be able to access Kibana at `localhost:5601`. Note that Kibana is exposed on every network interface available on the Docker host.
 


### PR DESCRIPTION
The beaker script is now installed to /usr/local/bin and doesn't need the `./` before it anymore. Additionally, I updated the commands to use the docker-compose service names rather than the container names.