### PR TITLE
Fix Loading ES Passwords With ='s; Improve Kibana Dashboard Upload Messaging

### DIFF
--- a/installer/stage/BeaKer/install_beaker.sh
+++ b/installer/stage/BeaKer/install_beaker.sh
@@ -168,7 +168,7 @@ install_beaker () {
 
     # Load password for kibana_import.sh.
     # Use docker_sudo since the env file ownership is root:docker.
-    local es_pass=`$docker_sudo grep ELASTIC_PASSWORD "$BEAKER_CONFIG_DIR/env" | cut -d= -f2`
+    local es_pass=`$docker_sudo grep '^ELASTIC_PASSWORD' "$BEAKER_CONFIG_DIR/env" | sed -e 's/^[^=][^=]*=//'`
 
     local connection_attempts=0
     local data_uploaded="false"

--- a/installer/stage/BeaKer/install_beaker.sh
+++ b/installer/stage/BeaKer/install_beaker.sh
@@ -174,9 +174,12 @@ install_beaker () {
     local data_uploaded="false"
     while [ $connection_attempts -lt 8 -a "$data_uploaded" != "true" ]; do
         if echo "$es_pass" | kibana/import_dashboards.sh "kibana/kibana_dashboards.ndjson" >&2 ; then
+            echo2 "The installer successfully uploaded dashboards to Kibana."
             data_uploaded="true"
             break
         fi
+        echo2 "The installer encountered an error while uploading dashboards to Kibana."
+        echo2 "Retrying..."
         sleep 15
         connection_attempts=$((connection_attempts + 1))
     done


### PR DESCRIPTION
Fixes loading Kibana dashboards when the `elastic` password contains an = sign.
Example error log that might be seen when this issue arises (Note that most of the errors are 401 errors):
```
================ Loading Kibana dashboards ================
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  129k    0     0  100  129k      0   4154  0:00:31  0:00:31 --:--:-- 35560
curl: (22) The requested URL returned error: 503 Service Unavailable
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  129k    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 401
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  129k    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 401
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  129k    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 401
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  129k    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 401
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  129k    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 401
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  129k    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 401
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  129k    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 401
The installer failed to load the Kibana dashboards
This is normally an unrecoverable problem, and we recommend fixing the problem and restarting the script. Please contact technical support for help in resolving the issue. If you feel the script should continue, enter   Y   and the script will attempt to finish. Entering   N    will cause this script to exit.
? 
```

The initial 503 error is a bit confusing since it is not apparent that the installer recovered and retried the upload. This PR adds language to the installer that says 

Example Output:
```
================ Loading Kibana dashboards ================
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  129k    0     0  100  129k      0   4154  0:00:31  0:00:31 --:--:-- 35560
curl: (22) The requested URL returned error: 503 Service Unavailable
The installer encountered an error while uploading dashboards to Kibana.
Retrying...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  129k    100     34  100  129k      18   71234  0:00:01  0:00:01 --:--:-- 71234
The installer successfully uploaded dashboards to Kibana.
```
