### PR TITLE
Added note to env file regarding password updating

### DIFF
--- a/installer/stage/BeaKer/install_beaker.sh
+++ b/installer/stage/BeaKer/install_beaker.sh
@@ -80,6 +80,14 @@ ensure_env_file_exists () {
 ###############################################################################
 
 ###############################################################################
+# Changing the elastic password in the Kibana UI requires also changing it
+# in this file.
+#
+# Once the password has been changed in both places, run "beaker up -d" to
+# restart the containers with the updated password.
+###############################################################################
+
+###############################################################################
 # Elastic Search Settings
 #
 ELASTIC_PASSWORD=${elastic_password}

--- a/installer/stage/BeaKer/install_beaker.sh
+++ b/installer/stage/BeaKer/install_beaker.sh
@@ -83,8 +83,8 @@ ensure_env_file_exists () {
 # Changing the elastic password in the Kibana UI requires also changing it
 # in this file.
 #
-# Once the password has been changed in both places, run "beaker up -d" to
-# restart the containers with the updated password.
+# Once the password has been changed in both places, run "beaker down" followed
+# by "beaker up -d" to restart the containers with the updated password.
 ###############################################################################
 
 ###############################################################################


### PR DESCRIPTION
This PR adds a quick note to the /etc/BeaKer/env file stating the password must be changed both in the env file and in the Kibana UI, Fixes #26.

It also mentions the "beaker up -d" command needed to complete that password change, that Bill mentioned we might want to document in Fixes #28  