### PR TITLE
Preserve environment so proxies work when using sudo

### DIFF
--- a/installer/stage/BeaKer/install_beaker.sh
+++ b/installer/stage/BeaKer/install_beaker.sh
@@ -155,7 +155,7 @@ install_beaker () {
     # Determine if the current user has permission to run docker
     local docker_sudo=""
     if [ ! -w "/var/run/docker.sock" ]; then
-        docker_sudo="sudo"
+        docker_sudo="sudo -E"
     fi
 
     # Load the docker images


### PR DESCRIPTION
Without the -E the http_proxy/https_proxy/HTTP_PROXY/HTTPS_PROXY environment variables get discarded when running sudo.