### PR TITLE
Mass deployment

### DIFF
--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -52,7 +52,7 @@ param (
 
 if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))  
 {  
-  $arguments = "& '" +$myinvocation.mycommand.definition + "'"
+  $arguments = "& '" +$myinvocation.mycommand.definition + "'", $args
   Start-Process powershell -Verb runAs -ArgumentList $arguments
   Break
 }

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -37,13 +37,6 @@ param (
     
 )
 
-if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))  
-{  
-  $arguments = "& '" +$myinvocation.mycommand.definition + "'", $args
-  Start-Process powershell -Verb runAs -ArgumentList $arguments
-  Break
-}
-
 if($ESCredential.username -eq $null)
 {
     $ESUsername=Read-Host "Elasticsearch username"

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -43,19 +43,19 @@ into the script in a secure environment. Instead, either leave the credentials b
 enter the credentials during the installation process, or edit the parameters' default values in the script.
 #>
 
-if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))  
-{  
-  $arguments = "& '" +$myinvocation.mycommand.definition + "'"
-  Start-Process powershell -Verb runAs -ArgumentList $arguments
-  Break
-}
-
 param (
     [Parameter(Mandatory=$true)][string]$ESHost,
     [string]$ESPort="9200",
     [string]$ESUsername="",
     [string]$ESPassword=""
 )
+
+if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))  
+{  
+  $arguments = "& '" +$myinvocation.mycommand.definition + "'"
+  Start-Process powershell -Verb runAs -ArgumentList $arguments
+  Break
+}
 
 if (-not (Test-Path "$Env:programfiles\Sysmon" -PathType Container)) {
   Invoke-WebRequest -OutFile Sysmon.zip https://download.sysinternals.com/files/Sysmon.zip

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -43,6 +43,13 @@ into the script in a secure environment. Instead, either leave the credentials b
 enter the credentials during the installation process, or edit the parameters' default values in the script.
 #>
 
+if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))  
+{  
+  $arguments = "& '" +$myinvocation.mycommand.definition + "'"
+  Start-Process powershell -Verb runAs -ArgumentList $arguments
+  Break
+}
+
 param (
     [Parameter(Mandatory=$true)][string]$ESHost,
     [string]$ESPort="9200",


### PR DESCRIPTION
This allows deployment of the BeaKer agent over a PS remote session as follows:
Invoke-Command -ComputerName (Get-Content .\systems.txt) -FilePath .\install-sysmon-beats.ps1 -ArgumentList "ip.of.BeaKer", "9200", $cred

systems.txt is a text file with the ips of each system the agent should be installed on, each on a new line.
$cred is a powershell credential object and can be defined with $cred = (Get-Credential)
If the agent is being installed locally, a credential object can be passed as an argument or the script will ask if none is provided. Passing the username/pass in plain text as arguments **doesn't work** with this change.

To whoever tests this out, shoot me an email (dave) if you need help setting up a windows environment that allows PS remoting. I suspect most real-life customers will already have it enabled in some way or another.