### PR TITLE
Set ACLs of ProgramData\winlogbeat to those of ProgramFiles\winlogbeat*

### DIFF
--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -160,6 +160,10 @@ if($ESPassword) {
   .\winlogbeat.exe --path.data "C:\ProgramData\winlogbeat" keystore add ES_PASSWORD
 }
 
+# Set ACL's of the $Env:ProgramData\winlogbeat folder to be the same as $Env:ProgramFiles\winlogbeat* (the main install path)
+# This helps ensure that "normal" users aren't able to access the $Env:ProgramData\winlogbeat folder
+Get-ACL -Path "$Env:ProgramFiles\winlogbeat*" | Set-ACL -Path "$Env:ProgramData\winlogbeat"
+
 rm .\winlogbeat.yml
 echo @"
 winlogbeat.event_logs:


### PR DESCRIPTION
This pull request adds a line to the agent install file so that we set the ACL's of $Env:ProgramData\winlogbeat to be the same as $Env:ProgramFIles\winlogbeat*. This will prevent "normal users" from being able to access the $Env:ProgramData\winlogbeat folder. Only users who would be able to access the $Env:ProgramFIles\winlogbeat* folder (the main installation folder) will be able to access the $Env:ProgramData\winlogbeat folder.

I tested to make sure that this doesn't break anything. I added the change into the file, ran the agent installer on a fresh Windows instance, and confirmed that my Beaker Elasticsearch server was correctly receiving data from the Windows instance by viewing that dat within Kibana.

Closes #43