### PR TITLE
Update elasticsearch to 7.16.1

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,2 +1,2 @@
-FROM elasticsearch:7.5.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.1
 ADD ./elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml


### PR DESCRIPTION
Closes #57
Updated the docker image for elasticsearch to 7.16.1. This also moves the build from pulling from DockerHub to pulling from elastic's docker registry.
Elasticsearch 7.16.1 takes care of the log4j vulnerability.

Tested on existing system with a Windows host feeding Kibana on BeaKer 0.0.8 and upgraded with no issues. Windows host continues to feed Kibana after upgrade.
There shouldn't be any caveats in upgrading clusters since BeaKer is single node. 