### PR TITLE
Updated Agent Script to Prevent Insecure ACLs

### DIFF
--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -181,10 +181,6 @@ if($ESPassword) {
   .\winlogbeat.exe --path.data "C:\ProgramData\winlogbeat" keystore add ES_PASSWORD
 }
 
-# Set ACL's of the $Env:ProgramData\winlogbeat folder to be the same as $Env:ProgramFiles\winlogbeat* (the main install path)
-# This helps ensure that "normal" users aren't able to access the $Env:ProgramData\winlogbeat folder
-Get-ACL -Path "$Env:ProgramFiles\winlogbeat*" | Set-ACL -Path "$Env:ProgramData\winlogbeat"
-
 rm .\winlogbeat.yml
 echo @"
 winlogbeat.event_logs:

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -161,11 +161,11 @@ if (-not (Test-Path "$Env:programfiles\winlogbeat*" -PathType Container)) {
   Invoke-WebRequest -OutFile WinLogBeat.zip https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-7.5.2-windows-x86_64.zip
   Expand-Archive .\WinLogBeat.zip
   remove-item .\WinLogBeat.zip
-  $winlogbeatName = Get-ChildItem | where-object name -like winlogbeat*
+  $winlogbeatName = Get-ChildItem -path .\WinlogBeat | where-object name -like winlogbeat*
   new-item -path "$Env:ProgramFiles\$($winlogbeatName.Name)" -ItemType Directory
-  $WinlogBeatFiles = Get-ChildItem .\$winlogbeatName
-  foreach ($file in $WinlogBeatFiles){copy-item -path ".\$($winlogbeatName.Name)\$file" -Destination "$Env:ProgramFiles\$($winlogbeatName.Name)"}
-  remove-item .\$winlogbeatName -Recurse
+  $WinlogBeatFiles = Get-ChildItem ".\WinLogBeat\$winlogbeatName"
+  foreach ($file in $WinlogBeatFiles){copy-item -path ".\WinLogBeat\$($winlogbeatName.Name)\$file" -Destination "$Env:ProgramFiles\$($winlogbeatName.Name)"}
+  remove-item .\WinLogBeat -Recurse
 }
 
 cd "$Env:programfiles\winlogbeat*\"
@@ -211,5 +211,5 @@ output.elasticsearch:
     enabled: true
     verification_mode: none
 "@ > winlogbeat.yml
-PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-winlogbeat.ps1
+PowerShell.exe -ExecutionPolicy UnRestricted -File "$Env:ProgramFiles\$($winlogbeatName.Name)\install-service-winlogbeat.ps1"
 Start-Service winlogbeat

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -164,7 +164,7 @@ if (-not (Test-Path "$Env:programfiles\winlogbeat*" -PathType Container)) {
   $winlogbeatName = Get-ChildItem -path .\WinlogBeat | where-object name -like winlogbeat*
   new-item -path "$Env:ProgramFiles\$($winlogbeatName.Name)" -ItemType Directory
   $WinlogBeatFiles = Get-ChildItem ".\WinLogBeat\$winlogbeatName"
-  foreach ($file in $WinlogBeatFiles){copy-item -path ".\WinLogBeat\$($winlogbeatName.Name)\$file" -Destination "$Env:ProgramFiles\$($winlogbeatName.Name)"}
+  foreach ($file in $WinlogBeatFiles){copy-item -path ".\WinLogBeat\$($winlogbeatName.Name)\$file" -Destination "$Env:ProgramFiles\$($winlogbeatName.Name)" -Recurse}
   remove-item .\WinLogBeat -Recurse
 }
 

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -74,8 +74,11 @@ if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
 if (-not (Test-Path "$Env:programfiles\Sysmon" -PathType Container)) {
   Invoke-WebRequest -OutFile Sysmon.zip https://download.sysinternals.com/files/Sysmon.zip
   Expand-Archive .\Sysmon.zip
-  rm .\Sysmon.zip
-  mv .\Sysmon\ "$Env:programfiles"
+  remove-item .\Sysmon.zip
+  new-item -path "$Env:ProgramFiles\Sysmon" -ItemType Directory
+  $SysmonFiles = Get-ChildItem .\Sysmon
+  foreach ($file in $SysmonFiles){copy-item -path "./Sysmon/$file" -Destination "$Env:programfiles\Sysmon"}
+  remove-item .\Sysmon -Recurse
 }
 
 echo @"

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -160,8 +160,12 @@ echo @"
 if (-not (Test-Path "$Env:programfiles\winlogbeat*" -PathType Container)) {
   Invoke-WebRequest -OutFile WinLogBeat.zip https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-7.5.2-windows-x86_64.zip
   Expand-Archive .\WinLogBeat.zip
-  rm .\WinLogBeat.zip
-  mv .\WinLogBeat\winlogbeat* "$Env:programfiles"
+  remove-item .\WinLogBeat.zip
+  $winlogbeatName = Get-ChildItem | where-object name -like winlogbeat*
+  new-item -path "$Env:ProgramFiles\$($winlogbeatName.Name)" -ItemType Directory
+  $WinlogBeatFiles = Get-ChildItem .\$winlogbeatName
+  foreach ($file in $WinlogBeatFiles){copy-item -path ".\$($winlogbeatName.Name)\$file" -Destination "$Env:ProgramFiles\$($winlogbeatName.Name)"}
+  remove-item .\$winlogbeatName -Recurse
 }
 
 cd "$Env:programfiles\winlogbeat*\"

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -77,7 +77,7 @@ if (-not (Test-Path "$Env:programfiles\Sysmon" -PathType Container)) {
   remove-item .\Sysmon.zip
   new-item -path "$Env:ProgramFiles\Sysmon" -ItemType Directory
   $SysmonFiles = Get-ChildItem .\Sysmon
-  foreach ($file in $SysmonFiles){copy-item -path "./Sysmon/$file" -Destination "$Env:programfiles\Sysmon"}
+  foreach ($file in $SysmonFiles){copy-item -path ".\Sysmon\$file" -Destination "$Env:programfiles\Sysmon"}
   remove-item .\Sysmon -Recurse
 }
 


### PR DESCRIPTION
The current method of installing Sysmon and WinlogBeat are opening up security holes due to an insecure ACL that is carried over when the .zip files are extracted. Specific concerns lay around the WinlogBeat folder permissions as any low priv user on the system is able to replace the service binary which the service will attempt to execute as SYSTEM allowing privilege escalation. 
![image](https://user-images.githubusercontent.com/36604349/183106350-c2dd4d73-7314-4b48-9730-c7db5e6e91ed.png)
A potential attacker could also just disable the service causing reduced visibility to the host. 
Sysmon is less of a concern as when it installs it copies the binaries to C:\Windows\System32 but should still be secured.
It looks like attempts to prevent this were in place in lines 177-180 but as you can see from the screenshot this was not working.