### PR TITLE
Use Ubuntu 20 for the Github runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   upload:
     name: Upload Artifacts
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The current github runner is broken since it uses Ubuntu 18. As a result the release build for v0.0.14 was not uploaded to the Github release when it was published. 