### PR TITLE
Give all users read/write permissions for snapshots directory

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -5,8 +5,7 @@ ADD ./elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
 RUN mkdir /usr/share/elasticsearch/snapshots
 # The elasticsearch container runs under the elasticsearch user
 # Make sure that the elasticsearch user has permission to read/save snapshots
-# (this matches the ownership of many other folders within the container)
-RUN chown elasticsearch:root /usr/share/elasticsearch/snapshots
-# Ensure write permissions for the snapshots directory
-RUN chmod -R 775 /usr/share/elasticsearch/snapshots
+# Since this directory is a bind mount, give all users read/write permissions
+# in order to avoid flaky write permissions when creating snapshots
+RUN chmod -R 777 /usr/share/elasticsearch/snapshots
 

--- a/installer/stage/BeaKer/install_beaker.sh
+++ b/installer/stage/BeaKer/install_beaker.sh
@@ -180,6 +180,7 @@ ensure_snapshot_repo_exists() {
     if [ ! -d "/opt/BeaKer/snapshots" ]; then 
         $SUDO mkdir "/opt/BeaKer/snapshots"
     fi
+    $SUDO chmod 777 /opt/BeaKer/snapshots
 }
 
 require_aih_web_server_listening () {

--- a/installer/stage/BeaKer/install_beaker.sh
+++ b/installer/stage/BeaKer/install_beaker.sh
@@ -291,7 +291,7 @@ create_snapshot() {
     local es_pass="$1"
 
     # Make sure the existing BeaKer install is running before attempting to create a snapshot
-    if [ `$SUDO docker ps | grep 'beaker_elasticsearch' | wc -l` -eq 0 ]; then
+    if [ `$SUDO docker ps | grep 'beaker-elasticsearch' | wc -l` -eq 0 ]; then
         echo "BeaKer doesn't appear to be running, starting..."
         ./beaker up -d
     fi


### PR DESCRIPTION
Closes #80 

In order to resolve the missing permissions on the snapshots directory for some BeaKer installs, the directory is given read/write permissions for all users. This shouldn't be an issue since the `/opt/BeaKer` directory requires admin/sudo access.

Testing:

I tried to replicate the issue on Ubuntu 20.04 with a fresh v0.0.13 BeaKer install and applying the current installer over it for ELK v7.17.9 and v8.7.0. I did not run into the failing snapshot creation during the upgrade. After the upgrade completed, manually created a snapshot via the snapshot API and was able to do so. I exec'd into the elasticsearch container and noted that the owner of the snapshots directory was `elasticsearch:root`, and was able to write to that directory via `echo "test" > test`. The `/opt/BeaKer/snapshots` folder was owned by `naomi:root`. Creating a file in `/opt/BeaKer/snapshots` created a file in `/usr/share/elasticsearch/snapshots` within the container. After running `beaker down` and `beaker up -d`, the permissions stayed the same.
I repeated the steps on CentOS 7 ( selinux mode permissive) with the same results.

I tested this PR using the same steps listed above on Ubuntu 20.04. Since the folder ownership change was removed, the owner is now `root:root` for both `/opt/BeaKer/snapshots` and `/usr/share/elasticsearch/snapshots` on the container. In my case, snapshot creation continues to succeed.