### PR TITLE
Move snapshot directory to /var/BeaKer/snapshots

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
     driver: local
     driver_opts:
       type: 'none'
-      device: /opt/BeaKer/snapshots
+      device: /var/BeaKer/snapshots
       o: bind
 services:
   elasticsearch:

--- a/installer/stage/BeaKer/install_beaker.sh
+++ b/installer/stage/BeaKer/install_beaker.sh
@@ -177,10 +177,10 @@ EOF
 
 ensure_snapshot_repo_exists() {
     # Create snapshot folder if it doesn't exist
-    if [ ! -d "/opt/BeaKer/snapshots" ]; then 
-        $SUDO mkdir "/opt/BeaKer/snapshots"
+    if [ ! -d "/var/BeaKer/snapshots" ]; then 
+        $SUDO mkdir "/var/BeaKer/snapshots"
     fi
-    $SUDO chmod 777 /opt/BeaKer/snapshots
+    $SUDO chmod 777 /var/BeaKer/snapshots
 }
 
 require_aih_web_server_listening () {

--- a/installer/stage/BeaKer/install_beaker.sh
+++ b/installer/stage/BeaKer/install_beaker.sh
@@ -178,7 +178,7 @@ EOF
 ensure_snapshot_repo_exists() {
     # Create snapshot folder if it doesn't exist
     if [ ! -d "/var/BeaKer/snapshots" ]; then 
-        $SUDO mkdir "/var/BeaKer/snapshots"
+        $SUDO mkdir -p "/var/BeaKer/snapshots"
     fi
     $SUDO chmod 777 /var/BeaKer/snapshots
 }


### PR DESCRIPTION
Closes #82 

The `/opt/BeaKer` directory is deleted upon every run of the installer. This means that the `snapshots` subdirectory and its files are also deleted. This PR moves the snapshots directory to `/var/BeaKer/snapshots`, which would not get deleted on every install.

Tested on Ubuntu 20.04 & CentOS 7
- Generated new BeaKer installer
- Installed new installer over a BeaKer v0.0.13 install
- Ran `./beaker down && beaker up -d` for sanity
- Ran the installer again to upgrade to Elastic v8.7.0 and created a snapshot
- Verified that snapshot was created and that the snapshot files were visible in `/var/BeaKer/snapshots` & `/usr/share/elasticsearch/snapshots`
- Ran the installer again to overwrite the v8.7.0 install, verified that the snapshot files were still in the host & container directories